### PR TITLE
Sanitize carriage return and tab

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -21,7 +21,7 @@ class CSVSafe < CSV
   private
 
   def starts_with_special_character?(str)
-    str.start_with?('-', '=', '+', '@', '%', '|')
+    str.start_with?("-", "=", "+", "@", "%", "|", "\r", "\t")
   end
 
   def prefix(field)

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe CSVSafe do
       it { should eq expected }
     end
 
+    context 'with a field that starts with a \r' do
+      let(:field) { "\r2+3+cmd|' /C calc'!'E2'" }
+      let(:expected) { "'\r2+3+cmd|' /C calc'!'E2'" }
+      it { should eq expected }
+    end
+
+    context 'with a field that starts with a \t' do
+      let(:field) { "\t2+3+cmd|' /C calc'!'E2'" }
+      let(:expected) { "'\t2+3+cmd|' /C calc'!'E2'" }
+      it { should eq expected }
+    end
+
     context 'with a field that starts with a @' do
       let(:field) { "@=-2+3+cmd|' /C calc'!'E2'" }
       let(:expected) { "'@=-2+3+cmd|' /C calc'!'E2'" }


### PR DESCRIPTION
- Adds \r and \t to the list of special characters to align with the OWASP recommendation: https://owasp.org/www-community/attacks/CSV_Injection
- It's not really clear why tab or carriage return would cause vulnerabilities, but yeah it can't hurt to add these
- I changed the double quotes to single quotes because:
```ruby
"\rabc".starts_with?("\r") # => true
"\rabc".starts_with?('\r') # => false