### PR TITLE
Fix headers nil error when generating a CSV w/ hash rows

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -53,7 +53,8 @@ class CSVSafe < CSV
     when self.class::Row
       then row.fields.map { |field| sanitize_field(field) }
     when Hash
-      then @headers.map { |header| sanitize_field(row[header]) }
+      @headers ||= headers
+      @headers.map { |header| sanitize_field(row[header]) }
     else
       row.map { |field| sanitize_field(field) }
     end

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -299,5 +299,16 @@ RSpec.describe CSVSafe do
       end
     end
   end
+
+  describe '#generate should work with hash rows without setting @headers instance variable' do
+    subject { CSVSafe.generate(headers: true) { |csv| csv << headers; csv << payload } }
+
+    context 'with a nil field' do
+      let(:headers) { %i[a b c] }
+      let(:payload) { { b: :b, a: :a, c: :c } }
+      let (:expected) { "a,b,c\na,b,c\n" }
+      it { should eq expected}
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- When calling `CSVSafe.generate`, `@headers` is nil which causes an error when calling `@headers.map`
- This PR fixes the issue by setting `@headers` to the result of the `headers` method if the instance variable does not yet have a value